### PR TITLE
Fix CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,96 +12,13 @@ LANGUAGES C Fortran
 
 enable_testing()
 
-option(SERIAL "Serial execution")
-
-# Set output paths for modules, archives, and executables
-set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/include)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-
-if(SERIAL)
-  message(STATUS "Configuring build for serial execution")
-else()
-  message(STATUS "Configuring build for parallel execution")
-endif()
-
 include(FetchContent)
 
-set(h5fortran_BUILD_TESTING false)
+include(cmake/options.cmake)
+include(cmake/compilers.cmake)
 
-FetchContent_Declare(
-  h5fortran
-  GIT_REPOSITORY https://github.com/geospace-code/h5fortran
-  GIT_TAG v4.6.3
-  GIT_SHALLOW true
-)
-
-FetchContent_Declare(
-  jsonfortran
-  GIT_REPOSITORY https://github.com/jacobwilliams/json-fortran
-  GIT_TAG 8.3.0
-  GIT_SHALLOW true
-)
-
-FetchContent_MakeAvailable(h5fortran jsonfortran)
-
-file(MAKE_DIRECTORY ${h5fortran_BINARY_DIR}/include)
-include_directories(${h5fortran_BINARY_DIR}/include)
-
-file(MAKE_DIRECTORY ${jsonfortran_BINARY_DIR}/include)
-include_directories(${jsonfortran_BINARY_DIR})
-
-list(APPEND CMAKE_MODULE_PATH ${h5fortran_SOURCE_DIR}/cmake/Modules)
-find_package(HDF5 COMPONENTS Fortran REQUIRED)
-
-# compiler flags for gfortran
-if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-
-  if(SERIAL)
-    message(STATUS "Configuring to build with -fcoarray=single")
-    add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-fcoarray=single>")
-  else()
-    add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-fcoarray=lib>")
-  endif()
-
-  if(BLAS)
-    add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-fexternal-blas;${BLAS}>")
-    list(APPEND LIBS "blas")
-    message(STATUS "Configuring build to use BLAS from ${BLAS}")
-  endif()
-
-  add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Debug>>:-fcheck=bounds;-fbacktrace>")
-  add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Release>>:-Ofast;-fno-frontend-optimize;-fno-backtrace>")
-
-elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^Intel")
-  # compiler flags for ifort
-
-  if(SERIAL)
-    message(STATUS "Configuring to build with -coarray=single")
-    if(WIN32)
-      add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:/Qcoarray:single>")
-    else()
-      add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-coarray=single>")
-    endif()
-  else()
-    if(WIN32)
-      add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:/Qcoarray:shared>")
-    else()
-      add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-coarray=shared>")
-    endif()
-  endif()
-
-  string(APPEND CMAKE_Fortran_FLAGS " -assume byterecl")
-  add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Debug>>:-check;-traceback>")
-  # add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Release>>:-O3>")
-
-elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
-  # compiler flags for Cray ftn
-  string(APPEND CMAKE_Fortran_FLAGS " -h noomp")
-  add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Debug>>:-O0;-g>")
-  add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Release>>:-O3>")
-endif()
+include(cmake/h5fortran.cmake)
+include(cmake/json.cmake)
 
 # library to archive (libneural.a)
 add_library(neural
@@ -145,8 +62,9 @@ add_library(neural
   src/nf/io/nf_io_hdf5.f90
   src/nf/io/nf_io_hdf5_submodule.f90
 )
-target_link_libraries(neural PRIVATE h5fortran::h5fortran HDF5::HDF5)
-target_include_directories(neural PRIVATE ${jsonfortran_BINARY_DIR}/include)
+target_link_libraries(neural PRIVATE h5fortran::h5fortran HDF5::HDF5 jsonfortran::jsonfortran)
+
+install(TARGETS neural)
 
 # Remove leading or trailing whitespace
 string(REGEX REPLACE "^ | $" "" LIBS "${LIBS}")
@@ -155,11 +73,11 @@ string(REGEX REPLACE "^ | $" "" LIBS "${LIBS}")
 
 foreach(execid input1d_layer input3d_layer dense_layer conv2d_layer maxpool2d_layer flatten_layer dense_network dense_network_from_keras conv2d_network io_hdf5 keras_read_model)
   add_executable(test_${execid} test/test_${execid}.f90)
-  target_link_libraries(test_${execid} PRIVATE neural h5fortran::h5fortran jsonfortran ${LIBS})
+  target_link_libraries(test_${execid} PRIVATE neural h5fortran::h5fortran jsonfortran::jsonfortran ${LIBS})
   add_test(test_${execid} bin/test_${execid})
 endforeach()
 
 foreach(execid cnn mnist mnist_from_keras simple sine)
   add_executable(${execid} example/${execid}.f90)
-  target_link_libraries(${execid} PRIVATE neural h5fortran::h5fortran jsonfortran ${LIBS})
+  target_link_libraries(${execid} PRIVATE neural h5fortran::h5fortran jsonfortran::jsonfortran ${LIBS})
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,20 @@
 # CMake version, project name, language
 cmake_minimum_required(VERSION 3.20)
-project(neural-fortran Fortran)
+
+# If build type not specified, default to release
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Default build Release")
+endif()
+
+project(neural-fortran LANGUAGES Fortran)
+
+option(SERIAL "Serial execution")
 
 # Set output paths for modules, archives, and executables
 set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/include)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-
-# If build type not specified, default to release
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "release")
-endif()
 
 if(SERIAL)
   message(STATUS "Configuring build for serial execution")
@@ -57,7 +60,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)
     set(LIBS "${LIBS} blas")
     message(STATUS "Configuring build to use BLAS from ${BLAS}")
   endif()
-    
+
   set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -fcheck=bounds -fbacktrace")
   set(CMAKE_Fortran_FLAGS_RELEASE "-Ofast -fno-frontend-optimize")
 endif()
@@ -140,7 +143,7 @@ foreach(execid input1d_layer input3d_layer dense_layer conv2d_layer maxpool2d_la
   target_link_libraries(test_${execid} PRIVATE neural h5fortran::h5fortran jsonfortran ${LIBS})
   add_test(test_${execid} bin/test_${execid})
 endforeach()
-  
+
 foreach(execid cnn mnist mnist_from_keras simple sine)
   add_executable(${execid} example/${execid}.f90)
   target_link_libraries(${execid} PRIVATE neural h5fortran::h5fortran jsonfortran ${LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,12 +34,14 @@ FetchContent_Declare(
   h5fortran
   GIT_REPOSITORY https://github.com/geospace-code/h5fortran
   GIT_TAG v4.6.3
+  GIT_SHALLOW true
 )
 
 FetchContent_Declare(
   jsonfortran
   GIT_REPOSITORY https://github.com/jacobwilliams/json-fortran
   GIT_TAG 8.3.0
+  GIT_SHALLOW true
 )
 
 FetchContent_MakeAvailable(h5fortran jsonfortran)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,15 +69,10 @@ install(TARGETS neural)
 # Remove leading or trailing whitespace
 string(REGEX REPLACE "^ | $" "" LIBS "${LIBS}")
 
-# tests
+if(${PROJECT_NAME}_BUILD_TESTING)
+  add_subdirectory(test)
+endif()
 
-foreach(execid input1d_layer input3d_layer dense_layer conv2d_layer maxpool2d_layer flatten_layer dense_network dense_network_from_keras conv2d_network io_hdf5 keras_read_model)
-  add_executable(test_${execid} test/test_${execid}.f90)
-  target_link_libraries(test_${execid} PRIVATE neural h5fortran::h5fortran jsonfortran::jsonfortran ${LIBS})
-  add_test(test_${execid} bin/test_${execid})
-endforeach()
-
-foreach(execid cnn mnist mnist_from_keras simple sine)
-  add_executable(${execid} example/${execid}.f90)
-  target_link_libraries(${execid} PRIVATE neural h5fortran::h5fortran jsonfortran::jsonfortran ${LIBS})
-endforeach()
+if(${PROJECT_NAME}_BUILD_EXAMPLES)
+  add_subdirectory(example)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,11 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Default build Release")
 endif()
 
-project(neural-fortran LANGUAGES Fortran)
+project(neural-fortran
+LANGUAGES C Fortran
+)
+
+enable_testing()
 
 option(SERIAL "Serial execution")
 
@@ -22,10 +26,9 @@ else()
   message(STATUS "Configuring build for parallel execution")
 endif()
 
-find_package(HDF5 COMPONENTS Fortran HL)
-include_directories(${HDF5_INCLUDE_DIRS})
-
 include(FetchContent)
+
+set(h5fortran_BUILD_TESTING false)
 
 FetchContent_Declare(
   h5fortran
@@ -47,47 +50,55 @@ include_directories(${h5fortran_BINARY_DIR}/include)
 file(MAKE_DIRECTORY ${jsonfortran_BINARY_DIR}/include)
 include_directories(${jsonfortran_BINARY_DIR})
 
+list(APPEND CMAKE_MODULE_PATH ${h5fortran_SOURCE_DIR}/cmake/Modules)
+find_package(HDF5 COMPONENTS Fortran REQUIRED)
+
 # compiler flags for gfortran
-if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)
+if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
 
   if(SERIAL)
     message(STATUS "Configuring to build with -fcoarray=single")
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fcoarray=single")
+    add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-fcoarray=single>")
+  else()
+    add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-fcoarray=lib>")
   endif()
 
   if(BLAS)
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fexternal-blas ${BLAS}")
-    set(LIBS "${LIBS} blas")
+    add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-fexternal-blas;${BLAS}>")
+    list(APPEND LIBS "blas")
     message(STATUS "Configuring build to use BLAS from ${BLAS}")
   endif()
 
-  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -fcheck=bounds -fbacktrace")
-  set(CMAKE_Fortran_FLAGS_RELEASE "-Ofast -fno-frontend-optimize")
-endif()
+  add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Debug>>:-fcheck=bounds;-fbacktrace>")
+  add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Release>>:-Ofast;-fno-frontend-optimize;-fno-backtrace>")
 
-# compiler flags for ifort
-if(CMAKE_Fortran_COMPILER_ID MATCHES Intel)
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^Intel")
+  # compiler flags for ifort
 
   if(SERIAL)
     message(STATUS "Configuring to build with -coarray=single")
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -coarray=single")
+    if(WIN32)
+      add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:/Qcoarray:single>")
+    else()
+      add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-coarray=single>")
+    endif()
+  else()
+    if(WIN32)
+      add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:/Qcoarray:shared>")
+    else()
+      add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-coarray=shared>")
+    endif()
   endif()
 
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -assume byterecl")
-  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -C -traceback")
-  set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+  string(APPEND CMAKE_Fortran_FLAGS " -assume byterecl")
+  add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Debug>>:-check;-traceback>")
+  # add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Release>>:-O3>")
 
-  if(NOT SERIAL)
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -coarray=shared")
-  endif()
-
-endif()
-
-# compiler flags for Cray ftn
-if(CMAKE_Fortran_COMPILER_ID MATCHES Cray)
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -h noomp")
-  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -g")
-  set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
+  # compiler flags for Cray ftn
+  string(APPEND CMAKE_Fortran_FLAGS " -h noomp")
+  add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Debug>>:-O0;-g>")
+  add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Release>>:-O3>")
 endif()
 
 # library to archive (libneural.a)
@@ -132,12 +143,14 @@ add_library(neural
   src/nf/io/nf_io_hdf5.f90
   src/nf/io/nf_io_hdf5_submodule.f90
 )
+target_link_libraries(neural PRIVATE HDF5::HDF5)
+target_include_directories(neural PRIVATE ${jsonfortran_BINARY_DIR}/include)
 
 # Remove leading or trailing whitespace
 string(REGEX REPLACE "^ | $" "" LIBS "${LIBS}")
 
 # tests
-enable_testing()
+
 foreach(execid input1d_layer input3d_layer dense_layer conv2d_layer maxpool2d_layer flatten_layer dense_network dense_network_from_keras conv2d_network io_hdf5 keras_read_model)
   add_executable(test_${execid} test/test_${execid}.f90)
   target_link_libraries(test_${execid} PRIVATE neural h5fortran::h5fortran jsonfortran ${LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ add_library(neural
   src/nf/io/nf_io_hdf5.f90
   src/nf/io/nf_io_hdf5_submodule.f90
 )
-target_link_libraries(neural PRIVATE HDF5::HDF5)
+target_link_libraries(neural PRIVATE h5fortran::h5fortran HDF5::HDF5)
 target_include_directories(neural PRIVATE ${jsonfortran_BINARY_DIR}/include)
 
 # Remove leading or trailing whitespace

--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -1,12 +1,3 @@
-include(CheckSourceCompiles)
-# Compiler capability test
-check_source_compiles(Fortran
-"program test
-character(kind=selected_char_kind('ISO_10646')) :: c
-end program"
-HAS_Fortran_UTF8
-)
-
 # compiler flags for gfortran
 if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
 

--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -1,3 +1,12 @@
+include(CheckSourceCompiles)
+# Compiler capability test
+check_source_compiles(Fortran
+"program test
+character(kind=selected_char_kind('ISO_10646')) :: c
+end program"
+HAS_Fortran_UTF8
+)
+
 # compiler flags for gfortran
 if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
 

--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -1,0 +1,51 @@
+# compiler flags for gfortran
+if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+
+  if(SERIAL)
+    message(STATUS "Configuring to build with -fcoarray=single")
+    add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-fcoarray=single>")
+  else()
+    add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-fcoarray=lib>")
+  endif()
+
+  if(BLAS)
+    add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-fexternal-blas;${BLAS}>")
+    list(APPEND LIBS "blas")
+    message(STATUS "Configuring build to use BLAS from ${BLAS}")
+  endif()
+
+  add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Debug>>:-fcheck=bounds;-fbacktrace>")
+  add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Release>>:-Ofast;-fno-frontend-optimize;-fno-backtrace>")
+
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^Intel")
+  # compiler flags for ifort
+
+  if(SERIAL)
+    message(STATUS "Configuring to build with -coarray=single")
+    if(WIN32)
+      add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:/Qcoarray:single>")
+    else()
+      add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-coarray=single>")
+    endif()
+  else()
+    if(WIN32)
+      add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:/Qcoarray:shared>")
+    else()
+      add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-coarray=shared>")
+    endif()
+  endif()
+
+  if(WIN32)
+    string(APPEND CMAKE_Fortran_FLAGS " /assume:byterecl")
+  else()
+    string(APPEND CMAKE_Fortran_FLAGS " -assume byterecl")
+  endif()
+  add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Debug>>:-check;-traceback>")
+  # add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Release>>:-O3>")
+
+elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
+  # compiler flags for Cray ftn
+  string(APPEND CMAKE_Fortran_FLAGS " -h noomp")
+  add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Debug>>:-O0;-g>")
+  add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Release>>:-O3>")
+endif()

--- a/cmake/h5fortran.cmake
+++ b/cmake/h5fortran.cmake
@@ -1,0 +1,15 @@
+set(h5fortran_BUILD_TESTING false)
+
+FetchContent_Declare(h5fortran
+  GIT_REPOSITORY https://github.com/geospace-code/h5fortran
+  GIT_TAG v4.6.3
+  GIT_SHALLOW true
+)
+
+FetchContent_MakeAvailable(h5fortran)
+
+file(MAKE_DIRECTORY ${h5fortran_BINARY_DIR}/include)
+
+
+list(APPEND CMAKE_MODULE_PATH ${h5fortran_SOURCE_DIR}/cmake/Modules)
+find_package(HDF5 COMPONENTS Fortran REQUIRED)

--- a/cmake/json.cmake
+++ b/cmake/json.cmake
@@ -23,7 +23,10 @@ ${_src}/json_module.F90
 )
 
 add_library(jsonfortran ${JF_LIB_SRCS})
-target_compile_definitions(jsonfortran PRIVATE ${JSON_REAL_KIND} ${JSON_INT_KIND})
+target_compile_definitions(jsonfortran PRIVATE
+${JSON_REAL_KIND} ${JSON_INT_KIND}
+$<$<BOOL:${HAS_Fortran_UTF8}>:USE_UCS4>
+)
 target_include_directories(jsonfortran PUBLIC
 $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
 $<INSTALL_INTERFACE:include>

--- a/cmake/json.cmake
+++ b/cmake/json.cmake
@@ -1,0 +1,35 @@
+# use our own CMake script to build jsonfortran instead of jsonfortran/CMakelists.txt
+
+FetchContent_Declare(jsonfortran
+  GIT_REPOSITORY https://github.com/jacobwilliams/json-fortran
+  GIT_TAG 8.3.0
+  GIT_SHALLOW true
+)
+
+FetchContent_Populate(jsonfortran)
+
+SET(JSON_REAL_KIND "REAL64")
+SET(JSON_INT_KIND "INT32")
+
+set(_src ${jsonfortran_SOURCE_DIR}/src)
+
+set (JF_LIB_SRCS
+${_src}/json_kinds.F90
+${_src}/json_parameters.F90
+${_src}/json_string_utilities.F90
+${_src}/json_value_module.F90
+${_src}/json_file_module.F90
+${_src}/json_module.F90
+)
+
+add_library(jsonfortran ${JF_LIB_SRCS})
+target_compile_definitions(jsonfortran PRIVATE ${JSON_REAL_KIND} ${JSON_INT_KIND})
+target_include_directories(jsonfortran PUBLIC
+$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+$<INSTALL_INTERFACE:include>
+)
+
+add_library(jsonfortran::jsonfortran INTERFACE IMPORTED GLOBAL)
+target_link_libraries(jsonfortran::jsonfortran INTERFACE jsonfortran)
+
+install(TARGETS jsonfortran)

--- a/cmake/json.cmake
+++ b/cmake/json.cmake
@@ -23,10 +23,7 @@ ${_src}/json_module.F90
 )
 
 add_library(jsonfortran ${JF_LIB_SRCS})
-target_compile_definitions(jsonfortran PRIVATE
-${JSON_REAL_KIND} ${JSON_INT_KIND}
-$<$<BOOL:${HAS_Fortran_UTF8}>:USE_UCS4>
-)
+target_compile_definitions(jsonfortran PRIVATE ${JSON_REAL_KIND} ${JSON_INT_KIND})
 target_include_directories(jsonfortran PUBLIC
 $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
 $<INSTALL_INTERFACE:include>

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,0 +1,13 @@
+option(SERIAL "Serial execution")
+
+# Set output paths for modules, archives, and executables
+set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+if(SERIAL)
+  message(STATUS "Configuring build for serial execution")
+else()
+  message(STATUS "Configuring build for parallel execution")
+endif()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,4 +1,6 @@
 option(SERIAL "Serial execution")
+option(${PROJECT_NAME}_BUILD_TESTING "build ${PROJECT_NAME} tests" true)
+option(${PROJECT_NAME}_BUILD_EXAMPLES "build ${PROJECT_NAME} examples" true)
 
 # Set output paths for modules, archives, and executables
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include)
@@ -10,4 +12,19 @@ if(SERIAL)
   message(STATUS "Configuring build for serial execution")
 else()
   message(STATUS "Configuring build for parallel execution")
+endif()
+
+# --- Generally useful CMake project options
+
+# Rpath options necessary for shared library install to work correctly in user projects
+set(CMAKE_INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/lib)
+set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
+
+# Necessary for shared library with Visual Studio / Windows oneAPI
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS true)
+
+# --- auto-ignore build directory
+if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)
+  file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
 endif()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,4 @@
+foreach(execid cnn mnist mnist_from_keras simple sine)
+  add_executable(${execid} ${execid}.f90)
+  target_link_libraries(${execid} PRIVATE neural h5fortran::h5fortran jsonfortran::jsonfortran ${LIBS})
+endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,3 +4,7 @@ foreach(execid input1d_layer input3d_layer dense_layer conv2d_layer maxpool2d_la
 
   add_test(NAME test_${execid} COMMAND test_${execid})
 endforeach()
+
+set_tests_properties(test_dense_network_from_keras test_io_hdf5 test_keras_read_model PROPERTIES
+RESOURCE_LOCK download
+)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,6 @@
+foreach(execid input1d_layer input3d_layer dense_layer conv2d_layer maxpool2d_layer flatten_layer dense_network dense_network_from_keras conv2d_network io_hdf5 keras_read_model)
+  add_executable(test_${execid} test_${execid}.f90)
+  target_link_libraries(test_${execid} PRIVATE neural h5fortran::h5fortran jsonfortran::jsonfortran ${LIBS})
+
+  add_test(NAME test_${execid} COMMAND test_${execid})
+endforeach()


### PR DESCRIPTION
This provides several fixes to CMake with regard to finding and linking HDF5 as well as canonical specification of compiler options. Now it's stuck on not finding json_module.mod from JsonFortran, I didn't look into that.

A key distinction is `find_package(HDF5 ...)` uses my FindHDF5.cmake in h5fortran, which works for more scenarios and generally is more robust than factory CMake FindHDF5.